### PR TITLE
Quick fix of path prefix problem in WINDOWS planform.

### DIFF
--- a/src/Syonix/LogViewer/LogFile.php
+++ b/src/Syonix/LogViewer/LogFile.php
@@ -32,7 +32,8 @@ class LogFile {
                 )));
                 break;
             case 'local':
-                $this->filesystem = new Filesystem(new Local("/"));
+                $this->filesystem = new Filesystem(new Local(dirname($this->args['path'])));
+                $this->args['path'] = basename($this->args['path']);
                 break;
             default:
                 throw new \InvalidArgumentException("Invalid log file type: \"" . $this->args['type']."\"");

--- a/views/log.html.twig
+++ b/views/log.html.twig
@@ -90,7 +90,7 @@
             <div class="level level-{{ logLevelStyle[level].class }}">
                 <i class="fa fa-{{ logLevelStyle[level].icon }}"></i>&nbsp;
             </div>
-            <div class="message{% if line.context|length > 0 %} has-more" onclick="toggleMore({{ id + 1 }});{% endif %}">{{ line.message }}</div>
+            <div class="message{% if line.context|length > 0 %} has-more" onclick="toggleMore({{ id + 1 }});{% endif %}">{{ line.logger }} {{ line.message }}</div>
             <div class="date">{{ line.date|date(app.config.dateFormat) }}</div>
             {% if line.context|length > 0 %}
                 <div class="more" id="more-{{ id + 1 }}" onclick="toggleMore({{ id + 1 }});"><i class="fa fa-search-plus"></i> more...</div>


### PR DESCRIPTION
There is problem under WINDOWS with new Filesystem(new Local("/")) in Syonix\LogViewer\LogFile.

This commit is a temporary fix.

For example:

```yaml
logs:
    Datafarm:
        P:
            type: local
            path: P:\xampp\htdocs\www\app\logs\base.log
```

When use $this->filesystem = new Filesystem(new Local("/"));

The $pathPrefix  is set to P:\, and the relative path is still P:\xampp\htdocs\www\app\logs\base.log

Then the full path will be: P:\P:\xampp\htdocs\www\app\logs\base.log will throw file not found exception.

```php

    public function has($path)
    {
        $location = $this->applyPathPrefix($path);

        return file_exists($location);
    }

    public function applyPathPrefix($path)
    {
        $path = ltrim($path, '\\/');

        if (strlen($path) === 0) {
            return $this->getPathPrefix() ?: '';
        }

        if ($prefix = $this->getPathPrefix()) {
            $path = $prefix.$path;
        }

        return $path;
    }

```