### PR TITLE
Showing newest logs first. Removed newest entry button

### DIFF
--- a/src/Syonix/LogViewer/LogFile.php
+++ b/src/Syonix/LogViewer/LogFile.php
@@ -45,7 +45,7 @@ class LogFile {
         }
 
         $file = $this->filesystem->read($this->args['path']);
-        $lines = explode("\n", $file);
+        $lines = array_reverse(explode("\n", $file));
         $parser = new LineLogParser();
         if(isset($this->args['pattern'])) {
             $hasCustomPattern = true;

--- a/views/log.html.twig
+++ b/views/log.html.twig
@@ -38,7 +38,6 @@
                 {% endfor %}
             </div>
         </li>
-        <li id="jump-to-newest" class="pull-right hide-if-mobile"><a href="#" onclick="$('#content').animate({ scrollTop: $('#content').prop('scrollHeight') - $('#content').height() }, 500); return false;"><i class="fa fa-lg fa-arrow-circle-down"></i> Newest entry</a></li>
         <li id="filter-text" class="pull-right show-if-js">
             <div id="filter-text-wrap">
                 <i class="fa fa-lg fa-search"></i>


### PR DESCRIPTION
Newest logs should show on top. Having to click a button every time to see latest logs is not user friendly.

There are two changes in this:
1. reversed the array of lines read from log file
2. Removed the newest entry button.