### PR TITLE
Fixing text selection on td.has-more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ app/config/secure/passwd
 app/config/config.yml
 .idea
 *.yml~
+.settings
+.project

--- a/web/css/screen.css
+++ b/web/css/screen.css
@@ -464,6 +464,10 @@ header#logs .filter-dropdown a.lower {
 
 .logline td.message.has-more {
     cursor: pointer;
+    -moz-user-select:-moz-none;
+    -ms-user-select:none;
+    -webkit-user-select:none;
+    user-select:none
 }
 
 .logline.level-critical .message,


### PR DESCRIPTION
If you open a `td.has-more` element and close it in quick succession, the text will get highlighted:
![clicking](https://cloud.githubusercontent.com/assets/8310677/11123673/4b2ca840-8961-11e5-900c-3d81f3fe2b8e.png)
This also occures if you click on the `td.has-more` and meanwhile move the cursor. 

To avoid it, you can specify that text-selection is not allowed when the element has the class `.has-more`.