### PR TITLE
Renaming Synoix\Util\String to StringUtil

### DIFF
--- a/src/Syonix/LogViewer/Client.php
+++ b/src/Syonix/LogViewer/Client.php
@@ -2,7 +2,7 @@
 namespace Syonix\LogViewer;
 
 use Doctrine\Common\Collections\ArrayCollection;
-use Syonix\Util\String;
+use Syonix\Util\StringUtil;
 
 class Client {
     protected $name;
@@ -25,7 +25,7 @@ class Client {
     public function setName($name)
     {
         $this->name = $name;
-        $this->slug = String::toAscii($name);
+        $this->slug = StringUtil::toAscii($name);
     }
 
     public function getSlug()

--- a/src/Syonix/LogViewer/LogFile.php
+++ b/src/Syonix/LogViewer/LogFile.php
@@ -6,7 +6,7 @@ use Dubture\Monolog\Parser\LineLogParser;
 use League\Flysystem\Adapter\Ftp;
 use League\Flysystem\Adapter\Local;
 use League\Flysystem\Filesystem;
-use Syonix\Util\String;
+use Syonix\Util\StringUtil;
 
 class LogFile {
     protected $name;
@@ -20,7 +20,7 @@ class LogFile {
         setlocale(LC_ALL, 'en_US.UTF8');
         
         $this->name = $name;
-        $this->slug = String::toAscii($name);
+        $this->slug = StringUtil::toAscii($name);
         $this->args = $args;
     }
 

--- a/src/Syonix/Util/StringUtil.php
+++ b/src/Syonix/Util/StringUtil.php
@@ -1,7 +1,7 @@
 <?php
 namespace Syonix\Util;
 
-class String
+class StringUtil
 {
     public static function toAscii($str, $replace=array(), $delimiter='-')
     {


### PR DESCRIPTION
String class causes errors because of new class name restrictions in PHP7. 'String' is now reserved word.
